### PR TITLE
Replace custom report_dir_path with the usual output_path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ Configure ``behat.yml``:
         extensions:
             Behat\JournalExtension\Extension:
                 driver: mink # available: mink, webdriver
+                capture_all: true # defaults to false to only capture on failure
 
 Launch your test suite with format **journal**:
 
@@ -33,6 +34,18 @@ Launch your test suite with format **journal**:
 
 This command will produce a file ``journal.html`` containing the HTML standard
 output with additional screenshots.
+
+Screenshot files will be placed in the same folder as the main output file.
+Any old screenshots are removed from the output folder first.
+
+To get another progress on screen while journal report is being generated, use behat.yml:
+
+.. code-block:: yaml
+
+    formatter:
+            name: journal,pretty
+            parameters:
+                output_path: wwwdocs/features/index.html,null
 
 To work, you have to use proper extension for it. Supported are:
 

--- a/src/Behat/JournalExtension/Extension.php
+++ b/src/Behat/JournalExtension/Extension.php
@@ -17,7 +17,6 @@ class Extension implements ExtensionInterface
         $loader->load('services.xml');
 
         $container->setParameter('behat.formatter.dispatcher.journal.capture_all', $config['capture_all']);
-        $container->setParameter('behat.formatter.dispatcher.journal.report_dir_path', $config['report_dir_path']);
         $container->setAlias('journal.driver', 'journal.driver.'.$config['driver']);
     }
 
@@ -28,14 +27,6 @@ class Extension implements ExtensionInterface
                 ->scalarNode('driver')->defaultValue('mink')->end()
                 ->booleanNode('capture_all')
                     ->defaultValue(false)
-                ->end()
-            ->end()
-        ;
-        $builder
-            ->children()
-                ->scalarNode('driver')->defaultValue('mink')->end()
-                ->variableNode('report_dir_path')
-                    ->defaultValue('reports/html')
                 ->end()
             ->end()
         ;

--- a/src/Behat/JournalExtension/Formatter/JournalFormatter.php
+++ b/src/Behat/JournalExtension/Formatter/JournalFormatter.php
@@ -18,13 +18,21 @@ class JournalFormatter extends HtmlFormatter {
     protected $screenShotMarkup;
     protected $screenShotDirectory;
 
-    public function __construct(DriverInterface $driver, $captureAll, $reportDirPath = 'reports/html') {
+    public function __construct(DriverInterface $driver, $captureAll) {
         $this->driver = $driver;
         $this->captureAll = $captureAll;
         $this->screenShotMarkup = '';
-        $this->screenShotDirectory = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . $reportDirPath;
-        array_map('unlink', glob($this->screenShotDirectory . DIRECTORY_SEPARATOR . "*.png"));
         parent::__construct();
+    }
+
+    protected function createOutputConsole() {
+        $output_path = $this->parameters->get('output_path');
+        if (!$output_path) {
+            $output_path = '.';
+        }
+        $this->screenShotDirectory = dirname($output_path);
+        array_map('unlink', glob($this->screenShotDirectory . DIRECTORY_SEPARATOR . $this->screenShotPrefix . "*.png"));
+        return parent::createOutputConsole();
     }
 
     /**
@@ -64,7 +72,7 @@ HTML
                 $screenshot = $this->driver->getScreenshot();
                 if ($screenshot) {
                     $date = new \DateTime('now');
-                    $fileName = 'Screen Shot ' . $date->format('Y-m-d H.i.s') . '.png';
+                    $fileName = $this->screenShotPrefix . $date->format('Y-m-d H.i.s') . '.png';
                     $file = $this->screenShotDirectory . DIRECTORY_SEPARATOR . $fileName;
                     file_put_contents($file, $screenshot);
                     $this->screenShotMarkup .= '<div class="screenshot">';

--- a/src/Behat/JournalExtension/services.xml
+++ b/src/Behat/JournalExtension/services.xml
@@ -4,7 +4,6 @@
         <service id="behat.formatter.dispatcher.journal" class="Behat\JournalExtension\Formatter\JournalDispatcher">
             <argument type="service" id="journal.driver" />
             <argument>%behat.formatter.dispatcher.journal.capture_all%</argument>
-            <argument>%behat.formatter.dispatcher.journal.report_dir_path%</argument>
 
             <tag name="behat.formatter.dispatcher" />
         </service>


### PR DESCRIPTION
With this change, we can use existing output_path formatter parameter to specify the html path.
Screenshots will be saved in the same folder as the HTML file (or current folder if path not provided.)

README file updated with additional instructions.