### PR TITLE
Add a way to skip duplicate screenshots

### DIFF
--- a/src/Behat/JournalExtension/Extension.php
+++ b/src/Behat/JournalExtension/Extension.php
@@ -26,7 +26,7 @@ class Extension implements ExtensionInterface
         $builder
             ->children()
                 ->scalarNode('driver')->defaultValue('mink')->end()
-                ->booleanNode('capture_all')
+                ->variableNode('capture_all')
                     ->defaultValue(false)
                 ->end()
             ->end()


### PR DESCRIPTION
Change type of capture_all parameter, and if set to "skip_duplicates"
remember last screenshot data and only save the next one if it is different.

This way we avoid many identical screenshots in "capture all" mode.
Reused existing parameter to avoid additional boolean args being sent around.