### PR TITLE
Zero length files

### DIFF
--- a/src/Behat/JournalExtension/Formatter/Driver/MinkDriver.php
+++ b/src/Behat/JournalExtension/Formatter/Driver/MinkDriver.php
@@ -34,6 +34,6 @@ class MinkDriver implements DriverInterface
             return $driver->getScreenshot();
         }
 
-        return $this->mink;
+        return;
     }
 }

--- a/src/Behat/JournalExtension/Formatter/JournalFormatter.php
+++ b/src/Behat/JournalExtension/Formatter/JournalFormatter.php
@@ -22,6 +22,7 @@ class JournalFormatter extends HtmlFormatter {
         $this->driver = $driver;
         $this->captureAll = $captureAll;
         $this->screenShotMarkup = '';
+        $this->screenShotPrefix = 'screenshot_';
         parent::__construct();
     }
 


### PR DESCRIPTION
This pull request fixes a couple of issues
- When taking a screenshot if the driver doesn't support screen capture at the moment the mink object is returned.  This causes an invalid file to be stored and a broken image in the report.
- The handler uses a variable screenShotPrefix which is never defined.  This also fixes that.
